### PR TITLE
Adding mobile support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
 	"repository_url": "https://github.com/supremekirb/joplin-todo-view",
 	"keywords": ["todo", "productivity"],
 	"categories": ["productivity", "personal knowledge management"],
+	"platforms": ["desktop", "mobile"],
 	"screenshots": [
 		{
 			"src": "assets/screenshots/example.png",


### PR DESCRIPTION
With adding mobile support in the manifest, I can load the plugin in the mobile web view for testing. However, when I click on a link, a new tab opens and I cant test the linking in the app. 

I don't know how to create jpl files to test it on my phone. Maybe you can help